### PR TITLE
Fix npm gulp dependency, since there is no longer a 4.0 branch of gulpjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.7.2",
     "browser-sync": "^2.10.0",
-    "gulp": "gulpjs/gulp#4.0",
+    "gulp": "4.0",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-babel": "^6.1.2",
     "gulp-clean-css": "^3.3.1",


### PR DESCRIPTION
gulpjs 4.0 is released, and #4.0 branch is deleted from their repository. This makes `npm install` fail when trying to install gulp. 

Updated gulp dependency in package.json, and now `npm install` is working again. 
